### PR TITLE
Replaced staticfiles with static

### DIFF
--- a/admin_tools/dashboard/templates/admin_tools/dashboard/css.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/css.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <link rel="stylesheet" href="{% static "admin_tools/css/dashboard.css" %}" type="text/css" media="screen, projection"/>
 <!--[if lt IE 8]>
 <link rel="stylesheet" href="{% static "admin_tools/css/dashboard-ie.css" %}" type="text/css" media="screen, projection"/>

--- a/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
+++ b/admin_tools/dashboard/templates/admin_tools/dashboard/dashboard.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles admin_tools_dashboard_tags %}
+{% load i18n static admin_tools_dashboard_tags %}
 
 {% block dashboard_scripts %}
 <script type="text/javascript" src="{% static "admin_tools/js/utils.js" %}"></script>

--- a/admin_tools/menu/templates/admin_tools/menu/css.html
+++ b/admin_tools/menu/templates/admin_tools/menu/css.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <link rel="stylesheet" href="{% static "admin_tools/css/menu.css" %}" type="text/css" media="screen, projection"/>
 <!--[if lt IE 8]>
 <link rel="stylesheet" href="{% static "admin_tools/css/menu-ie.css" %}" type="text/css" media="screen, projection"/>

--- a/admin_tools/menu/templates/admin_tools/menu/menu.html
+++ b/admin_tools/menu/templates/admin_tools/menu/menu.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles admin_tools_menu_tags %}
+{% load i18n static admin_tools_menu_tags %}
 {% if menu.children %}
 <script type="text/javascript" charset="utf-8">
     // Load js files syncronously and conditionally


### PR DESCRIPTION
@alextreme, `remove-jquery-as-well` branch word gebruikt als package in belastingdienst-gegevensstromen. Alleen het werkte niet met Django versie 3.2 dus ik heb het geupdate zodat we deze fork kunnen blijven gebruiken.